### PR TITLE
Use import-package instead of require-bundle for slf4j

### DIFF
--- a/io.takari.m2e.incrementalbuild.core/META-INF/MANIFEST.MF
+++ b/io.takari.m2e.incrementalbuild.core/META-INF/MANIFEST.MF
@@ -11,8 +11,8 @@ Require-Bundle: org.eclipse.m2e.maven.runtime;bundle-version="1.5.0",
  org.eclipse.core.resources;bundle-version="3.9.0",
  org.eclipse.core.runtime;bundle-version="3.10.0",
  org.eclipse.core.filesystem;bundle-version="1.4.100",
- org.slf4j.api;bundle-version="1.6.2",
  io.takari.builder.takari-builder-security-manager;bundle-version="0.20.5",
  io.takari.incrementalbuild.workspace;bundle-version="0.20.5"
+Import-Package: org.slf4j;version="1.6.2"
 Bundle-Activator: io.takari.m2e.incrementalbuild.core.internal.activator.M2EIncrementalBuildActivator
 Bundle-ActivationPolicy: lazy


### PR DESCRIPTION
In some environments this bundle has a different symbolic name. By
using import-package, you ensure this plugin can work everywhere.

Signed-off-by: Mat Booth <mat.booth@redhat.com>